### PR TITLE
fixed a possible bug in the definition of the time stamps for the membership functions

### DIFF
--- a/cosmic.py
+++ b/cosmic.py
@@ -46,7 +46,7 @@ def compute_score(width, t_k, tt_k):
         
         # get time stamps of membership functions (pulse trains)
         dt      = width/50
-        t_lower = min(min(t_k), min(tt_k)) + width     
+        t_lower = min(min(t_k), min(tt_k)) - width     
         t_upper = max(max(t_k), max(tt_k)) + width         
         t       = np.arange(t_lower, t_upper, dt)
         t_len   = len(t)


### PR DESCRIPTION
hey! I have been using your code and think this line should be changed. The code fails for single spikes otherwise:

MWE:

compute_score(0.1,np.array([1]),np.array([1]))